### PR TITLE
도커 호환성 이슈 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.2.5'
+    id 'org.springframework.boot' version '3.4.0'
     id 'io.spring.dependency-management' version '1.1.4'
 }
 
@@ -8,7 +8,7 @@ group = 'org'
 version = '0.0.1-SNAPSHOT'
 
 java {
-    sourceCompatibility = '17'
+    sourceCompatibility = '23'
 }
 
 configurations {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,10 +31,7 @@ services:
       - idea-network
   spring-idea:
     container_name: spring-idea
-    image: openjdk:17-alpine
-    # build:
-    #   dockerfile: Dockerfile
-    #   context: ./
+    image: eclipse-temurin:23-alpine
     ports:
       - "8888:8888"
     depends_on:

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Closed #49 

- apple silicon 에서도 호환되는 도커 이미지 사용
- 버전 올리기
  - 자바 (17 -> 23)
  - spring-boot (3.2.5 -> 3.4.0)
  - gradle (8.7 -> 8.11.1)